### PR TITLE
fix(directive): normalize names in prop and event bindings

### DIFF
--- a/src/directive.ts
+++ b/src/directive.ts
@@ -76,7 +76,8 @@ export const directiveFactory = [
             // Set up event bindings.
             eventExprPairs.forEach(([eventName, parsedExpr]) => {
               elem.on(eventName, evt => {
-                var callback = parsedExpr.bind(null, scope, { $event: evt });
+                evt = evt.originalEvent || evt;
+                const callback = parsedExpr.bind(null, scope, { $event: evt });
 
                 if (!$rootScope.$$phase) {
                   scope.$apply(callback);


### PR DESCRIPTION
It seems when jQuery is used, it will usually wrap the original CustomEvent which breaks the
interface of the expected detail payload